### PR TITLE
Fixed deadlock during destruction

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -32,6 +32,7 @@
 #ifndef TF2_ROS__TRANSFORM_LISTENER_H_
 #define TF2_ROS__TRANSFORM_LISTENER_H_
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <thread>
@@ -142,8 +143,13 @@ private:
 
       // Create executor with dedicated thread to spin.
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+      running_ = true;
       executor_->add_callback_group(callback_group_, node_base_interface_);
-      dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
+      dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {
+        while (running_.load()) {
+          executor_->spin_once();
+        }
+      });
       // Tell the buffer we have a dedicated thread to enable timeouts
       buffer_.setUsingDedicatedThread(true);
     } else {
@@ -160,6 +166,7 @@ private:
   // ros::CallbackQueue tf_message_callback_queue_;
   bool spin_thread_{false};
   std::unique_ptr<std::thread> dedicated_listener_thread_;
+  std::atomic<bool> running_;
   rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
   rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
 

--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -143,7 +143,7 @@ private:
 
       // Create executor with dedicated thread to spin.
       executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-      running_ = true;
+      running_.store(true);
       executor_->add_callback_group(callback_group_, node_base_interface_);
       dedicated_listener_thread_ = std::make_unique<std::thread>([&]() {
         while (running_.load()) {

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -61,6 +61,7 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
 TransformListener::~TransformListener()
 {
   if (spin_thread_) {
+    running_.store(false);
     executor_->cancel();
     dedicated_listener_thread_->join();
   }


### PR DESCRIPTION
The destructor in tf2_ros::TransformListener causes a deadlock in rare cases, which results that the spin thread never terminates. This causes flaky unit tests.

Relevant issues:
https://github.com/ros2/geometry2/issues/517
https://github.com/ros2/geometry2/pull/518